### PR TITLE
Fixed the ability to delete default conditions

### DIFF
--- a/succ/modules/butler.js
+++ b/succ/modules/butler.js
@@ -111,6 +111,7 @@ export const SETTING_KEYS = {
         coreEffects: "coreStatusEffects",
         map: "activeConditionMap",
         defaultMap: "defaultConditionMap",
+        deletedConditionsMap: "deletedConditionsMap",
         mapType: "conditionMapType",
         removeDefaultEffects: "removeDefaultEffects",
         outputChat: "conditionsOutputToChat",

--- a/succ/modules/enhanced-conditions/condition-lab.js
+++ b/succ/modules/enhanced-conditions/condition-lab.js
@@ -18,6 +18,7 @@ export class ConditionLab extends FormApplication {
         this.mapType = null;
         this.initialMap = Sidekick.getSetting(BUTLER.SETTING_KEYS.enhancedConditions.map);
         this.map = null;
+        this.deletedConditionsMap = Sidekick.getSetting(BUTLER.SETTING_KEYS.enhancedConditions.deletedConditionsMap);
         this.displayedMap = null;
         this.filterValue = "";
         this.sortDirection = "";
@@ -232,6 +233,8 @@ export class ConditionLab extends FormApplication {
             Sidekick.setSetting(BUTLER.SETTING_KEYS.enhancedConditions.coreEffects, CONFIG.defaultStatusEffects);
             Sidekick.setSetting(BUTLER.SETTING_KEYS.enhancedConditions.specialStatusEffectMapping, CONFIG.defaultSpecialStatusEffects);
         }
+        
+        Sidekick.setSetting(BUTLER.SETTING_KEYS.enhancedConditions.deletedConditionsMap, []);
 
         // If the mapType is other then the map should be empty, otherwise it's the default map for the system
         const tempMap = (this.mapType != otherMapType && defaultMap) ? defaultMap : [];
@@ -306,6 +309,7 @@ export class ConditionLab extends FormApplication {
 
         await Sidekick.setSetting(BUTLER.SETTING_KEYS.enhancedConditions.mapType, mapType, true);
         await Sidekick.setSetting(BUTLER.SETTING_KEYS.enhancedConditions.map, preparedMap, true);
+        await Sidekick.setSetting(BUTLER.SETTING_KEYS.enhancedConditions.deletedConditionsMap, this.deletedConditionsMap, true);
 
         return this._finaliseSave(preparedMap);
     }
@@ -702,6 +706,7 @@ export class ConditionLab extends FormApplication {
                     label: game.i18n.localize("WORDS._Yes"),
                     callback: async event => {
                         const newMap = duplicate(this.map);
+                        this.deletedConditionsMap.push(newMap[row]);
                         newMap.splice(row, 1);
                         this.map = newMap;
                         this.render();

--- a/succ/modules/enhanced-conditions/enhanced-conditions.js
+++ b/succ/modules/enhanced-conditions/enhanced-conditions.js
@@ -1075,6 +1075,7 @@ export class EnhancedConditions {
     static async updateConditionMapFromDefaults() {
         let conditionMap = Sidekick.getSetting(BUTLER.SETTING_KEYS.enhancedConditions.map);
         let defaultMap = Sidekick.getSetting(BUTLER.SETTING_KEYS.enhancedConditions.defaultMap);
+        let deletedConditionsMap = Sidekick.getSetting(BUTLER.SETTING_KEYS.enhancedConditions.deletedConditionsMap);
         if (!conditionMap.length || !defaultMap) {
             return;
         }
@@ -1107,7 +1108,10 @@ export class EnhancedConditions {
         for (let defaultCondition of defaultMap) {
             const condition = conditionMap.find(c => c.name === defaultCondition.name);
             if (!condition) {
-                conditionMap.push(duplicate(defaultCondition));
+                const deletedCondition = deletedConditionsMap.find(c => c.name === defaultCondition.name);
+                if (!deletedCondition) {
+                    conditionMap.push(duplicate(defaultCondition));
+                }
             } else {
                 if (!defaultCondition.activeEffect) {
                     //The default condition doesn't have an active effect, so we'll just leave whatever is in the condition alone

--- a/succ/modules/settings.js
+++ b/succ/modules/settings.js
@@ -40,6 +40,12 @@ export function registerSettings() {
         default: {}
     });
 
+    Sidekick.registerSetting(BUTLER.SETTING_KEYS.enhancedConditions.deletedConditionsMap, {
+        scope: "world",
+        type: Object,
+        default: []
+    });
+
     Sidekick.registerSetting(BUTLER.SETTING_KEYS.enhancedConditions.map, {
         name: "SETTINGS.EnhancedConditions.ActiveConditionMapN",
         hint: "SETTINGS.EnhancedConditions.ActiveConditionMapH",


### PR DESCRIPTION
With some of the stuff I did to support automatically grabbing logic from the system, I ended up breaking the ability to delete conditions that appear in the default system conditions. This fixes that.