### PR TITLE
Changes to the condition lab to make custom the only valid type to edit conditions

### DIFF
--- a/succ/lang/cn.json
+++ b/succ/lang/cn.json
@@ -222,7 +222,7 @@
 	"ENHANCED_CONDITIONS.Lab.RestoreDefaults.Body": "<p>您确定要将此映射恢复为默认值吗？</p><strong>如果您保存，此更改将是永久性的。</strong>",
 	"ENHANCED_CONDITIONS.Lab.ActiveEffects.TitleDisabledNew": "主动效果配置（禁用 - 首先保存映射）",
 	"ENHANCED_CONDITIONS.Lab.RestoreDefaults.ClearCache.CheckboxText": "清除缓存并从模组文件夹重新加载默认值？",
-	"ENHANCED_CONDITIONS.Lab.ActiveEffects.TitleDisabledDefault": "主动效果配置（禁用 - 无法编辑默认映射）",
+	"ENHANCED_CONDITIONS.Lab.ActiveEffects.TitleDisabledNotCustom": "主动效果配置（禁用 - 无法编辑默认映射）",
 	"ENHANCED_CONDITIONS.Condition.Lower": "削弱特性",
 	"ENHANCED_CONDITIONS.Dialog.Trait": "特性： ",
 	"ENHANCED_CONDITIONS.Dialog.BoostBuilder.Name": "强化特性构建器",

--- a/succ/lang/de.json
+++ b/succ/lang/de.json
@@ -166,7 +166,7 @@
     "ENHANCED_CONDITIONS.Lab.MappingType.Unsaved": "(ungespeicherte Änderungen)",
     "ENHANCED_CONDITIONS.Lab.ActiveEffects.Title": "Aktive Effekte-Konfiguration",
     "ENHANCED_CONDITIONS.Lab.ActiveEffects.TitleDisabledNew": "Aktive Effekte-Konfiguration (Deaktiviert - Zuordnung zuerst speichern)",
-    "ENHANCED_CONDITIONS.Lab.ActiveEffects.TitleDisabledDefault": "Aktive Effekte-Konfiguration (Deaktiviert - Kann Standard-Zuordnung nicht bearbeiten)",
+    "ENHANCED_CONDITIONS.Lab.ActiveEffects.TitleDisabledNotCustom": "Aktive Effekte-Konfiguration (Deaktiviert - Kann Standard-Zuordnung nicht bearbeiten)",
     "ENHANCED_CONDITIONS.LAB.Import.NoFile": "Keine Datendatei hochgeladen!",
     "ENHANCED_CONDITIONS.Lab.ConfirmDeleteTitle": "Zeilenlöschung bestätigen",
     "ENHANCED_CONDITIONS.Lab.ConfirmDeleteContent": "Diese Zeile wirklich löschen?",

--- a/succ/lang/en.json
+++ b/succ/lang/en.json
@@ -204,7 +204,7 @@
     "ENHANCED_CONDITIONS.Lab.ActiveEffects.Button": "Active Effect",
     "ENHANCED_CONDITIONS.Lab.ActiveEffects.Title": "Active Effect Config",
     "ENHANCED_CONDITIONS.Lab.ActiveEffects.TitleDisabledNew": "Active Effect Config (Disabled - Save Mapping First)",
-    "ENHANCED_CONDITIONS.Lab.ActiveEffects.TitleDisabledDefault": "Active Effect Config (Disabled - Cannot Edit Default Mapping)",
+    "ENHANCED_CONDITIONS.Lab.ActiveEffects.TitleDisabledNotCustom": "Active Effect Config (Disabled - Can Only Edit Custom Mappings)",
     "ENHANCED_CONDITIONS.Lab.SaveMacro.Button": "Save Toggle Macro",
     "ENHANCED_CONDITIONS.Lab.SaveMacro.Title": "Creates a toggle condition macro and adds it to the hotbar",
     "ENHANCED_CONDITIONS.Lab.CreatedToggleMacro.Name": "Toggle ",

--- a/succ/lang/ja.json
+++ b/succ/lang/ja.json
@@ -68,7 +68,7 @@
     "ENHANCED_CONDITIONS.Lab.MappingType.Unsaved": "（未保存の変更）",
     "ENHANCED_CONDITIONS.Lab.ActiveEffects.Title": "アクティブ効果設定",
     "ENHANCED_CONDITIONS.Lab.ActiveEffects.TitleDisabled": "アクティブ効果設定（無効：最初にマッピングの保存を行ってください）",
-    "ENHANCED_CONDITIONS.Lab.ActiveEffects.TitleDisabledDefault": "アクティブ効果設定（無効：デフォルトマッピングを編集できません）",
+    "ENHANCED_CONDITIONS.Lab.ActiveEffects.TitleDisabledNotCustom": "アクティブ効果設定（無効：デフォルトマッピングを編集できません）",
     "ENHANCED_CONDITIONS.LAB.Import.NoFile": "データファイルがアップロードされていません！",
     "ENHANCED_CONDITIONS.Lab.ConfirmDeleteTitle": "行の削除確認",
     "ENHANCED_CONDITIONS.Lab.ConfirmDeleteContent": "本当にこの行を削除しますか？",

--- a/succ/lang/ko.json
+++ b/succ/lang/ko.json
@@ -67,7 +67,7 @@
     "ENHANCED_CONDITIONS.Lab.MappingType.Unsaved": "(저장되지 않은 변화 내역)",
     "ENHANCED_CONDITIONS.Lab.ActiveEffects.Title": "활성화 효과 설정",
     "ENHANCED_CONDITIONS.Lab.ActiveEffects.TitleDisabled": "활성화 효과 설정 (비활성화됨 - 우선 매핑 저장 해주세요)",
-    "ENHANCED_CONDITIONS.Lab.ActiveEffects.TitleDisabledDefault": "활성화 효과 설정 (비활성화 - 매핑 기본값을 수정할 수 없음)",
+    "ENHANCED_CONDITIONS.Lab.ActiveEffects.TitleDisabledNotCustom": "활성화 효과 설정 (비활성화 - 매핑 기본값을 수정할 수 없음)",
     "ENHANCED_CONDITIONS.LAB.Import.NoFile": "데이터 파일을 업로드하지 않았습니다!",
     "ENHANCED_CONDITIONS.Lab.ConfirmDeleteTitle": "행 삭제 확인",
     "ENHANCED_CONDITIONS.Lab.ConfirmDeleteContent": "이 행을 삭제하시겠습니까?",

--- a/succ/lang/pt-BR.json
+++ b/succ/lang/pt-BR.json
@@ -179,7 +179,7 @@
 	"ENHANCED_CONDITIONS.Lab.Title": "Laboratório de Condições",
 	"ENHANCED_CONDITIONS.Lab.MappingType.Label": "Tipo de Mapeamento",
 	"ENHANCED_CONDITIONS.Lab.MappingType.Unsaved": "(alterações não salvas)",
-	"ENHANCED_CONDITIONS.Lab.ActiveEffects.TitleDisabledDefault": "Active Effect Config (Desativado - Não é possível editar o mapeamento padrão)",
+	"ENHANCED_CONDITIONS.Lab.ActiveEffects.TitleDisabledNotCustom": "Active Effect Config (Desativado - Não é possível editar o mapeamento padrão)",
 	"ENHANCED_CONDITIONS.Lab.Import.NoFile": "Você não fez upload de um arquivo de dados!",
 	"ENHANCED_CONDITIONS.Lab.RestoreDefaults.ClearCache.CheckboxText": "Limpar o cache e recarregar os padrões da pasta do módulo?",
 	"ENHANCED_CONDITIONS.Lab.RestoreDefaults.KeepAdded.CheckboxText": "Manter as condições adicionadas por meio do Laboratório de Condições?",

--- a/succ/modules/signal.js
+++ b/succ/modules/signal.js
@@ -90,6 +90,9 @@ export class Signal {
             EnhancedConditions._onDeleteActiveEffect(effect, options, userId);
         });
 
+        Hooks.on("updateActiveEffect", (effect, options, userId) => {
+        });
+
         Hooks.on("updateActor", (tokenDocument, updateData, options, userId) => {
             EnhancedConditions._onUpdateActor(tokenDocument, updateData, options, userId);
         });

--- a/succ/templates/condition-lab.hbs
+++ b/succ/templates/condition-lab.hbs
@@ -34,11 +34,11 @@
     
     <ol class="condition-lab list">
         {{#each displayedMap as |condition key|}}
-        {{> "modules/succ/templates/partials/condition-lab-row.hbs" condition=condition key=key isDefault=../isDefault conditionMapLength=../displayedMap.length sortDirection=../sortDirection}}
+        {{> "modules/succ/templates/partials/condition-lab-row.hbs" condition=condition key=key isCustom=../isCustom conditionMapLength=../displayedMap.length sortDirection=../sortDirection}}
         {{/each}}
         <div class="flexrow add-row">
             <a name="add-row" title="Add Row">
-                <i class="fas fa-plus"></i> {{#if isDefault}}Add Row (switch to System - Custom){{else}}Add Row{{/if}}
+                <i class="fas fa-plus"></i> {{#if isCustom}}Add Row{{else}}Add Row (switch to System - Custom){{/if}}
             </a>
         </div>
     </ol>

--- a/succ/templates/enhanced-condition-option-config.hbs
+++ b/succ/templates/enhanced-condition-option-config.hbs
@@ -8,12 +8,12 @@
         <section class="condition-options">
             <div class="tab active" data-group="main" data-tab="general-options">
                 <div class="formgroup">
-                    <label><input type="checkbox" name="overlay" {{checked condition.options.overlay}} {{#if ../isDefault}}disabled{{/if}}>
+                    <label><input type="checkbox" name="overlay" {{checked condition.options.overlay}} {{#unless ../isCustom}}disabled{{/unless}}>
                         {{localize "ENHANCED_CONDITIONS.Lab.Options.Overlay.Label"}}</label>
                     <p class="notes">{{localize "ENHANCED_CONDITIONS.Lab.Options.Overlay.Title"}}</p>
                 </div>
                 <div class="formgroup">
-                    <label><input type="checkbox" name="remove-others" {{checked condition.options.removeOthers}} {{#if ../isDefault}}disabled{{/if}}>
+                    <label><input type="checkbox" name="remove-others" {{checked condition.options.removeOthers}} {{#unless ../isCustom}}disabled{{/unless}}>
                         {{localize "ENHANCED_CONDITIONS.Lab.Options.RemoveOthers.Label"}}</label>
                     <p class="notes">{{localize "ENHANCED_CONDITIONS.Lab.Options.RemoveOthers.Title"}}</p>
                 </div>
@@ -33,52 +33,52 @@
 
             <div class="tab" data-group="main" data-tab="special-effects">
                 <div class="formgroup">
-                    <label><input type="checkbox" name="blind-token" {{checked condition.options.blindToken}} {{#if ../isDefault}}disabled{{/if}}>
+                    <label><input type="checkbox" name="blind-token" {{checked condition.options.blindToken}} {{#unless ../isCustom}}disabled{{/unless}}>
                         {{localize "succ.ENHANCED_CONDITIONS.OptionConfig.BlindToken.Label"}}</label>
                     <p class="notes">{{localize "succ.ENHANCED_CONDITIONS.OptionConfig.BlindToken.Notes"}}</p>
                 </div>
                 <div class="formgroup">
-                    <label><input type="checkbox" name="mark-invisible" {{checked condition.options.markInvisible}} {{#if ../isDefault}}disabled{{/if}}>
+                    <label><input type="checkbox" name="mark-invisible" {{checked condition.options.markInvisible}} {{#unless ../isCustom}}disabled{{/unless}}>
                         {{localize "succ.ENHANCED_CONDITIONS.OptionConfig.MarkInvisible.Label"}}</label>
                     <p class="notes">{{localize "succ.ENHANCED_CONDITIONS.OptionConfig.MarkInvisible.Notes"}}</p>
                 </div>
                 <div class="formgroup">
-                    <label><input type="checkbox" name="cold-bodied" {{checked condition.options.coldBodied}} {{#if ../isDefault}}disabled{{/if}}>
+                    <label><input type="checkbox" name="cold-bodied" {{checked condition.options.coldBodied}} {{#unless ../isCustom}}disabled{{/unless}}>
                         {{localize "succ.ENHANCED_CONDITIONS.OptionConfig.ColdBodied.Label"}}</label>
                     <p class="notes">{{localize "succ.ENHANCED_CONDITIONS.OptionConfig.ColdBodied.Notes"}}</p>
                 </div>
                 <div class="formgroup">
-                    <label><input type="checkbox" name="boost-trait" {{checked condition.options.boostTrait}} {{#if ../isDefault}}disabled{{/if}}>
+                    <label><input type="checkbox" name="boost-trait" {{checked condition.options.boostTrait}} {{#unless ../isCustom}}disabled{{/unless}}>
                         {{localize "succ.ENHANCED_CONDITIONS.OptionConfig.BoostTrait.Label"}}</label>
                     <p class="notes">{{localize "succ.ENHANCED_CONDITIONS.OptionConfig.BoostTrait.Notes"}}</p>
                 </div>
                 <div class="formgroup">
-                    <label><input type="checkbox" name="lower-trait" {{checked condition.options.lowerTrait}} {{#if ../isDefault}}disabled{{/if}}>
+                    <label><input type="checkbox" name="lower-trait" {{checked condition.options.lowerTrait}} {{#unless ../isCustom}}disabled{{/unless}}>
                         {{localize "succ.ENHANCED_CONDITIONS.OptionConfig.LowerTrait.Label"}}</label>
                     <p class="notes">{{localize "succ.ENHANCED_CONDITIONS.OptionConfig.Smite.Notes"}}</p>
                 </div>
                 <div class="formgroup">
-                    <label><input type="checkbox" name="smite" {{checked condition.options.smite}} {{#if ../isDefault}}disabled{{/if}}>
+                    <label><input type="checkbox" name="smite" {{checked condition.options.smite}} {{#unless ../isCustom}}disabled{{/unless}}>
                         {{localize "succ.ENHANCED_CONDITIONS.OptionConfig.Smite.Label"}}</label>
                     <p class="notes">{{localize "succ.ENHANCED_CONDITIONS.OptionConfig.Smite.Notes"}}</p>
                 </div>
                 <div class="formgroup">
-                    <label><input type="checkbox" name="protection" {{checked condition.options.protection}} {{#if ../isDefault}}disabled{{/if}}>
+                    <label><input type="checkbox" name="protection" {{checked condition.options.protection}} {{#unless ../isCustom}}disabled{{/unless}}>
                         {{localize "succ.ENHANCED_CONDITIONS.OptionConfig.Protection.Label"}}</label>
                     <p class="notes">{{localize "succ.ENHANCED_CONDITIONS.OptionConfig.Protection.Notes"}}</p>
                 </div>
                 <div class="formgroup">
-                    <label><input type="checkbox" name="deflection" {{checked condition.options.deflection}} {{#if ../isDefault}}disabled{{/if}}>
+                    <label><input type="checkbox" name="deflection" {{checked condition.options.deflection}} {{#unless ../isCustom}}disabled{{/unless}}>
                         {{localize "succ.ENHANCED_CONDITIONS.OptionConfig.Deflection.Label"}}</label>
                     <p class="notes">{{localize "succ.ENHANCED_CONDITIONS.OptionConfig.Deflection.Notes"}}</p>
                 </div>
                 <div class="formgroup">
-                    <label><input type="checkbox" name="conviction" {{checked condition.options.conviction}} {{#if ../isDefault}}disabled{{/if}}>
+                    <label><input type="checkbox" name="conviction" {{checked condition.options.conviction}} {{#unless ../isCustom}}disabled{{/unless}}>
                         {{localize "succ.ENHANCED_CONDITIONS.OptionConfig.Conviction.Label"}}</label>
                     <p class="notes">{{localize "succ.ENHANCED_CONDITIONS.OptionConfig.Conviction.Notes"}}</p>
                 </div>
                 <div class="formgroup">
-                    <label><input type="checkbox" name="encumbered" {{checked condition.options.encumbered}} {{#if ../isDefault}}disabled{{/if}}>
+                    <label><input type="checkbox" name="encumbered" {{checked condition.options.encumbered}} {{#unless ../isCustom}}disabled{{/unless}}>
                         {{localize "succ.ENHANCED_CONDITIONS.OptionConfig.Encumbered.Label"}}</label>
                     <p class="notes">{{localize "succ.ENHANCED_CONDITIONS.OptionConfig.Encumbered.Notes"}}</p>
                 </div>

--- a/succ/templates/partials/condition-lab-row.hbs
+++ b/succ/templates/partials/condition-lab-row.hbs
@@ -16,14 +16,14 @@
                     <div class="condition">
                         <div class="wrapper-rel">
                             <label for="condition-{{@index}}" class="inset-label">{{localize "succ.WORDS.Name"}}</label>
-                            <input type="text" name="condition-{{@index}}" title="Condition" value="{{condition.name}}" class="condition condition-text-input" placeholder="Condition Name" data-dtype="String" {{#if isDefault}}disabled{{/if}}>
+                            <input type="text" name="condition-{{@index}}" title="Condition" value="{{condition.name}}" class="condition condition-text-input" placeholder="Condition Name" data-dtype="String" {{#unless isCustom}}disabled{{/unless}}>
                         </div>
                     </div>
                 </div>
                 <div class="flexrow condition-lab text-entry reference">
                     <div class="wrapper-rel">
                         <label for="reference-item-{{@index}}" class="inset-label">{{localize "succ.WORDS.Reference"}}</label>
-                        <input type="text" name="reference-item-{{@index}}" value="{{condition.referenceId}}" title="Condition Reference" placeholder="{{localize "succ.ENHANCED_CONDITIONS.ConditionLab.NoReference"}}" {{#if isDefault}}disabled{{/if}}>
+                        <input type="text" name="reference-item-{{@index}}" value="{{condition.referenceId}}" title="Condition Reference" placeholder="{{localize "succ.ENHANCED_CONDITIONS.ConditionLab.NoReference"}}" {{#unless isCustom}}disabled{{/unless}}>
                     </div>
                     <div class="enriched-link">{{{condition.enrichedReference}}}</div>
                 </div>
@@ -33,9 +33,9 @@
         <div class="flexrow path">
             <div class="wrapper-rel">
                 <label for="icon-path-{{@index}}" class="inset-label">{{localize "succ.WORDS.Icon"}}</label>
-                <input type="text" name="icon-path-{{@index}}" title="Status Icon Path" class="icon-path condition-text-input" value="{{condition.img}}" placeholder="/icons/example.svg" data-dtype="String" {{#if isDefault}}disabled{{/if}}>
+                <input type="text" name="icon-path-{{@index}}" title="Status Icon Path" class="icon-path condition-text-input" value="{{condition.img}}" placeholder="/icons/example.svg" data-dtype="String" {{#unless isCustom}}disabled{{/unless}}>
             </div>
-            <button type="button" name="file-picker-{{@index}}" class="file-picker" data-type="image" data-target="icon-path-{{@index}}" title="Browse Files" tabindex="-1" {{#if isDefault}}hidden{{/if}}>
+            <button type="button" name="file-picker-{{@index}}" class="file-picker" data-type="image" data-target="icon-path-{{@index}}" title="Browse Files" tabindex="-1" {{#unless isCustom}}disabled{{/unless}}>
                 <i class="fas fa-file-import fa-fw"></i>
             </button>
         </div>
@@ -54,10 +54,10 @@
                     class="active-effect-config"
                     title="{{#if condition.isNew}}
                         {{localize "ENHANCED_CONDITIONS.Lab.ActiveEffects.TitleDisabledNew"}}
-                        {{else if isDefault}}{{localize "ENHANCED_CONDITIONS.Lab.ActiveEffects.TitleDisabledDefault"}}
+                        {{else unless isCustom}}{{localize "ENHANCED_CONDITIONS.Lab.ActiveEffects.TitleDisabledNotCustom"}}
                         {{else}}{{localize "ENHANCED_CONDITIONS.Lab.ActiveEffects.Title"}}
                         {{/if}}" 
-                    {{#if (or condition.isNew isDefault) }}disabled{{else}}{{/if}}>
+                    {{#unless (and (eq condition.isNew false) isCustom) }}disabled{{/unless}}>
                 <i class="fas fa-hand-sparkles"></i> {{localize "ENHANCED_CONDITIONS.Lab.ActiveEffects.Button"}}
             </button>
             <div class="flex-break"></div>
@@ -83,7 +83,7 @@
             {{/unless}}
         </div>
         <div class="remove-row">
-            {{#unless isDefault}}
+            {{#unless isCustom}}
             {{#unless destroyDisabled}}
             <a name="remove-row-{{@index}}" class="remove-row" title="Delete Row">
                 <i class="fas fa-trash"></i>


### PR DESCRIPTION
It's no longer possible to edit conditions in the other tab. Instead the user must switch to custom in order to edit.
Adding a new condition in the lab now always switches to custom